### PR TITLE
feat: add blog posts to sitemap

### DIFF
--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,5 +1,6 @@
 import { type MetadataRoute } from 'next';
 
+import { getBlogPosts } from '$/services/blog';
 import { ListingsTypeOptions } from '$/utils/pocketbase/pocketbase-types';
 import { createStaticClient } from '$/utils/pocketbase/static';
 
@@ -20,6 +21,12 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     fields: 'id,updated',
   });
 
+  const allBlogPosts = await getBlogPosts(1, 9999);
+  const blogPostUrls = allBlogPosts.items.map((post) => ({
+    url: `${BASE_URL}/blog/${post.slug}`,
+    lastModified: new Date(post.updated),
+  }));
+
   return [
     { url: BASE_URL, lastModified: new Date() },
     { url: `${BASE_URL}/airsoft-occasion`, lastModified: new Date(), changeFrequency: 'daily', priority: 1.0 },
@@ -36,5 +43,6 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
       url: `${BASE_URL}/profile/${user.id}`,
       lastModified: new Date(user.updated),
     })),
+    ...blogPostUrls,
   ];
 }

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,6 +1,7 @@
 import { type MetadataRoute } from 'next';
 
-import { getBlogPosts } from '$/services/blog';
+// import { getBlogPosts } from '$/services/blog'; // Old import
+import { getAllBlogPosts } from '$/services/blog'; // New import
 import { ListingsTypeOptions } from '$/utils/pocketbase/pocketbase-types';
 import { createStaticClient } from '$/utils/pocketbase/static';
 
@@ -21,8 +22,9 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     fields: 'id,updated',
   });
 
-  const allBlogPosts = await getBlogPosts(1, 9999);
-  const blogPostUrls = allBlogPosts.items.map((post) => ({
+  // const allBlogPostsListResult = await getBlogPosts(1, 9999); // Old call
+  const allBlogPosts = await getAllBlogPosts(); // New call
+  const blogPostUrls = allBlogPosts.map((post) => ({ // Adjusted to map directly over the array
     url: `${BASE_URL}/blog/${post.slug}`,
     lastModified: new Date(post.updated),
   }));

--- a/src/services/blog.ts
+++ b/src/services/blog.ts
@@ -32,3 +32,12 @@ export async function getBlogPostBySlug(
     return null;
   }
 }
+
+export async function getAllBlogPosts(): Promise<BlogResponse[]> {
+  const pb = await createStaticClient();
+  const records = await pb.collection('blog').getFullList<BlogResponse>({
+    sort: '-created',
+    fields: 'slug,updated,created',
+  });
+  return records;
+}


### PR DESCRIPTION
This change modifies the sitemap generation process to include URLs for all blog posts.

The `sitemap.ts` file now fetches all blog posts using the `getBlogPosts` service and maps them to the sitemap structure, including their slug and last updated date.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Blog post URLs are now included in the sitemap, improving site coverage for search engines.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->